### PR TITLE
update jasmine import for angular 8 datatable

### DIFF
--- a/src/DataTable.spec.ts
+++ b/src/DataTable.spec.ts
@@ -1,4 +1,4 @@
-///<reference path="../node_modules/@types/jasmine/index.d.ts"/>
+///<reference path="../../../node_modules/@types/jasmine/index.d.ts"/>
 import { SimpleChange, Component } from "@angular/core";
 import { DataTable, PageEvent, SortEvent } from "./DataTable";
 import { TestBed, ComponentFixture } from "@angular/core/testing";


### PR DESCRIPTION
after installing angular 8 datatable in an angular project it gives an exception as it can't import jasmine.